### PR TITLE
fix: add fixed salary in prompt to base_offer description

### DIFF
--- a/leetcomp/prompts.py
+++ b/leetcomp/prompts.py
@@ -10,7 +10,7 @@ Each dictionary must include the following keys with their respective values:
 - company (str): The name of the company offering the job.
 - role (str): The job title or role being offered.
 - yoe (float): The years of experience of the candidate receiving the offer.
-- base_offer (float): The base salary component of the offer, in LPA (INR).
+- base_offer (float): The base salary component of the offer, in LPA (INR), which is also called as fixed salary.
   For example, "29.5 LPA" should be represented as 29.5. Avoid scientific notation.
   Salary in crores like "1.18 cr" should be converted to LPA (1.18 * 100 = 118).
 - total_offer (float): The total compensation offered, in LPA (INR).


### PR DESCRIPTION
Added fix salary term in the prompt to be considered as base_offer.
the `base_salary` was being returned as `'n/a'` when running through `gemma3:12b`, on certain posts, eg.  [here](https://leetcode.com/discuss/post/7166280/uber-india-l5-sse-bengaluru-by-anonymous-zgan/) 

Small change in prompt fixes that. 